### PR TITLE
[DO NOT MERGE] Add gadget plugin

### DIFF
--- a/plugins/auth-proxy.yaml
+++ b/plugins/auth-proxy.yaml
@@ -16,10 +16,10 @@ spec:
     You need to configure authentication in the kubeconfig.
     See https://github.com/int128/kauthproxy for more.
 
-  version: v1.0.0
+  version: v1.0.1
   platforms:
-    - uri: https://github.com/int128/kauthproxy/releases/download/v1.0.0/kauthproxy_linux_amd64.zip
-      sha256: "dfcc56c0e8e980149dd641c32419a4da7f59d793d3359a730ec62b5445196fe8"
+    - uri: https://github.com/int128/kauthproxy/releases/download/v1.0.1/kauthproxy_linux_amd64.zip
+      sha256: "71b232f2e8e953321b29eb6076305e2504479dc342ffe307e4e81be61c25b168"
       bin: kauthproxy
       files:
         - from: kauthproxy
@@ -30,8 +30,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-    - uri: https://github.com/int128/kauthproxy/releases/download/v1.0.0/kauthproxy_darwin_amd64.zip
-      sha256: "217597c2c2e18f336f6d11b6d76982ada426e420a8786f092407adec9962e6e0"
+    - uri: https://github.com/int128/kauthproxy/releases/download/v1.0.1/kauthproxy_darwin_amd64.zip
+      sha256: "096aaa92eb423a7b40b18e034d13bb13bdd68266535369900db32b8ec415cb07"
       bin: kauthproxy
       files:
         - from: kauthproxy
@@ -42,8 +42,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-    - uri: https://github.com/int128/kauthproxy/releases/download/v1.0.0/kauthproxy_windows_amd64.zip
-      sha256: "bc38b7c23f991833441f1ed718271028313430cb1ef45bb433e44ba47f633527"
+    - uri: https://github.com/int128/kauthproxy/releases/download/v1.0.1/kauthproxy_windows_amd64.zip
+      sha256: "fb14dcb059e95dcebd4c7d8591eb93d89052ee1919e896be7a396eefa839ef21"
       bin: kauthproxy.exe
       files:
         - from: kauthproxy.exe

--- a/plugins/gadget.yaml
+++ b/plugins/gadget.yaml
@@ -1,0 +1,42 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: gadget
+spec:
+  version: v0.1.0
+  homepage: https://github.com/kinvolk/inspektor-gadget
+  shortDescription: Collection of gadgets for debugging and introspecting Kubernetes applications
+  description: |
+    Inspektor Gadget is a collection of tools (or gadgets) for developers of
+    Kubernetes applications.
+
+    Inspektor Gadget is deployed to each node as a privileged DaemonSet.
+    It uses in-kernel BPF helper programs to monitor events mainly related to
+    syscalls from userspace programs in a pod. The BPF programs are run by
+    the kernel and gather the log data. Inspektor Gadget's userspace utilities
+    fetch the log data from ring buffers and display it. What BPF programs are
+    and how Inspektor Gadget uses them is briefly explained in the architecture
+    document:
+    https://github.com/kinvolk/inspektor-gadget/blob/master/Documentation/architecture.md
+  caveats: |
+    Inspektor Gadget needs to be deployed to each node:
+
+    $ kubectl gadget deploy | kubectl apply -f -
+
+    Read the documentation available at https://github.com/kinvolk/inspektor-gadget
+    to get more information about the server side installation process.
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/kinvolk/inspektor-gadget/releases/download/v0.1.0/inspektor-gadget-linux-amd64.tar.gz
+    sha256: b0f6078d37d96e7efbf946d893c12007d4e09fcc8b0ed2cf77912ff2e661513f
+    bin: kubectl-gadget
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/kinvolk/inspektor-gadget/releases/download/v0.1.0/inspektor-gadget-darwin-amd64.tar.gz
+    sha256: e32708a3e9704cdc98190a1500d9eaf1e7850d68f2f7ce81984c70905fca4277
+    bin: kubectl-gadget

--- a/plugins/images.yaml
+++ b/plugins/images.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: images
 spec:
-  version: v0.1.0
+  version: v0.2.0
   homepage: https://github.com/chenjiandongx/kubectl-images
   shortDescription: Show container images used in the cluster.
   description: |
@@ -15,20 +15,20 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/chenjiandongx/kubectl-images/releases/download/v0.1.0/kubectl-images_darwin_amd64.tar.gz
-    sha256: 885bfd428a8cb09189f7c3da1b9bff2a0f8dc13a47707ec98b4071ce6f7a92d1
+    uri: https://github.com/chenjiandongx/kubectl-images/releases/download/v0.2.0/kubectl-images_darwin_amd64.tar.gz
+    sha256: 7b3751496a87596b820ab9794ea5bb3e21ce590d1409380badcf60629a98764d
     bin: kubectl-images
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/chenjiandongx/kubectl-images/releases/download/v0.1.0/kubectl-images_linux_amd64.tar.gz
-    sha256: 1c42a4f2e4e803f3b9b2d736b095193f7c47a7c7853f337e9f4f82798cf404d2
+    uri: https://github.com/chenjiandongx/kubectl-images/releases/download/v0.2.0/kubectl-images_linux_amd64.tar.gz
+    sha256: 1b415a711cd0a501e89e9a8b7322eba8277f45443385fc20a409600d081306c4
     bin: kubectl-images
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/chenjiandongx/kubectl-images/releases/download/v0.1.0/kubectl-images_windows_amd64.tar.gz
-    sha256: e35aa6023df73d8b8218e8891643a90da91f2113e0366c2839876a0e1e4d6e82
+    uri: https://github.com/chenjiandongx/kubectl-images/releases/download/v0.2.0/kubectl-images_windows_amd64.tar.gz
+    sha256: 28b2caae745cfa7867b6617de65cd1ca1ca75096f2d96c30de91b8a23facb665
     bin: kubectl-images

--- a/plugins/roll.yaml
+++ b/plugins/roll.yaml
@@ -1,0 +1,29 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: roll
+spec:
+  homepage: https://github.com/LifeWay/kubectl-roll-plugin
+  shortDescription: Rolling restart of all persistent pods in a namespace
+  version: v1.0.4
+  description: |
+    A utility to slowly delete all pods in a namespace that are
+    controlled by Deployments, StatefulSets, and DaemonSets. You must
+    correctly configure readiness probes to avoid any downtime.
+
+    Usage:
+      kubectl roll -n <namespace>
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: os
+        operator: In
+        values:
+        - darwin
+        - linux
+    uri: https://github.com/LifeWay/kubectl-roll-plugin/archive/1.0.4.tar.gz
+    sha256: d0e408fefdbc078410f4021644d9b03236be1f215aaaba79e2e786ef3ae10344
+    bin: roll
+    files:
+    - from: kubectl-roll-plugin-1.0.4/kubectl-roll
+      to: roll

--- a/plugins/support-bundle.yaml
+++ b/plugins/support-bundle.yaml
@@ -3,14 +3,14 @@ kind: Plugin
 metadata:
   name: support-bundle
 spec:
-  version: v0.9.34
+  version: v0.9.36
   platforms:
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.34/support-bundle_linux_amd64.tar.gz
-    sha256: a03cb455a4e01bcba783dc381bab4f8a8806a10aeeb19fab4b904044d5728a68
+    uri: https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.36/support-bundle_linux_amd64.tar.gz
+    sha256: 71a74e9776bc5837298d863def3847db4f39abd0612ce635a6c88bdc60922e05
     files:
     - from: support-bundle
       to: .
@@ -21,8 +21,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.34/support-bundle_darwin_amd64.tar.gz
-    sha256: 8e6389a4ace8c25527209c39ccbf5d009b63eb962a1a0e044272aef52277df42
+    uri: https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.36/support-bundle_darwin_amd64.tar.gz
+    sha256: b7648489c3b919a23bf9508f0d693b11678c892fdc7c0804585d3dd94e74bbe0
     files:
     - from: support-bundle
       to: .
@@ -33,8 +33,8 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.34/support-bundle.exe_windows_amd64.zip
-    sha256: 07093257f9188f8ae5b6f1b836e9bb3612c4a3f635e466e18d3aabf16cf5b09c
+    uri: https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.36/support-bundle_windows_amd64.zip
+    sha256: 80b12c0c53cebe5e67cefe02379446be1872d7808863436385aea9c8336177aa
     files:
     - from: support-bundle.exe
       to: .


### PR DESCRIPTION
Inspektor Gadget is a collection of tools (gadgets) for debugging and
instrospecting Kubernetes applications.

More info is at https://github.com/kinvolk/inspektor-gadget.

---
It's an internal PR to review that the wording in the template is fine.

It can be tested locally by ` krew install --manifest=gadget.yaml`
Krew installation notes: https://krew.sigs.k8s.io/docs/user-guide/setup/install/.
Once this PR is approved I'll open it against the https://github.com/kubernetes-sigs/krew-index/ repo.
